### PR TITLE
Fix image related workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,9 +3,11 @@ on: [pull_request]
 jobs:
   build-images:
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: ghcr.io/${{ github.repository }}
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
@@ -16,5 +18,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: false
-          tags: gchr.io/${{ github.repository }}:latest-amd64
+          tags: ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-amd64
           file: ./Dockerfile

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -6,9 +6,11 @@ on:
 jobs:
   build-push-amd64:
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: ghcr.io/${{ github.repository }}
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
@@ -19,7 +21,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -33,16 +35,18 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest-amd64
+            ghcr.io/${{ steps.repo_name.outputs.repository }}:latest-amd64
           labels: ${{ steps.docker_meta.outputs.labels }}
           file: ./Dockerfile
 
   create-push-manifest:
     needs: [build-push-amd64]
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: ghcr.io/${{ github.repository }}
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -54,6 +58,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest for multi-arch images
+        env:
+          REPOSITORY: ghcr.io/${{ steps.repo_name.outputs.repository }}
         run: |
           # Get artifacts from previous steps
           docker pull ${{ env.REPOSITORY }}:latest-amd64

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -8,6 +8,10 @@ jobs:
     name: Image push/amd64
     runs-on: ubuntu-latest
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
@@ -25,7 +29,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
 
@@ -35,7 +39,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:stable-amd64
+            ghcr.io/${{ steps.repo_name.outputs.repository }}:stable-amd64
             ${{ steps.docker_meta.outputs.tags }}-amd64
           labels: ${{ steps.docker_meta.outputs.labels }}
           file: ./Dockerfile
@@ -43,9 +47,11 @@ jobs:
   create-push-manifest:
     needs: [build-push-amd64]
     runs-on: ubuntu-latest
-    env:
-      REPOSITORY: ghcr.io/${{ github.repository }}
     steps:
+      - name: Set repository as lower-case output variable
+        id: repo_name
+        run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -53,7 +59,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
 
@@ -65,6 +71,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest for multi-arch images
+        env:
+          REPOSITORY: ghcr.io/${{ steps.repo_name.outputs.repository }}
         run: |
           # Get artifacts from previous steps
           docker pull ${{ steps.docker_meta.outputs.tags }}-amd64


### PR DESCRIPTION
docker buildx is unable to cope with upper case
letters in image repository.

The following is seen in logs of push-main workflow:

```
error: invalid tag
"ghcr.io/Mellanox/multi-networkpolicy-tc:latest-amd64":
repository name must be lowercase
```

To cope with this, convert repository name to lowercase

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>