### PR TITLE
Add builder to Ingress QDisc

### DIFF
--- a/pkg/tc/actuator_file_writer_test.go
+++ b/pkg/tc/actuator_file_writer_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Actuator file writer tests", Ordered, func() {
 	var tempDir string
 	var logger klog.Logger
 	var actuator tc.Actuator
+	ingressQdisc := types.NewIngressQDiscBuilder().Build()
 
 	BeforeAll(func() {
 		// init logger
@@ -47,7 +48,7 @@ var _ = Describe("Actuator file writer tests", Ordered, func() {
 			nonExistentPath := filepath.Join(tempDir, "does", "not", "exist")
 			actuator = tc.NewActuatorFileWriterImpl(nonExistentPath, logger)
 			objs := &tc.TCObjects{
-				QDisc: types.NewIngressQdisc(),
+				QDisc: ingressQdisc,
 			}
 			err := actuator.Actuate(objs)
 			Expect(err).To(HaveOccurred())
@@ -57,7 +58,7 @@ var _ = Describe("Actuator file writer tests", Ordered, func() {
 			invalidPath := ""
 			actuator = tc.NewActuatorFileWriterImpl(invalidPath, logger)
 			objs := &tc.TCObjects{
-				QDisc: types.NewIngressQdisc(),
+				QDisc: ingressQdisc,
 			}
 			err := actuator.Actuate(objs)
 			Expect(err).To(HaveOccurred())
@@ -67,7 +68,7 @@ var _ = Describe("Actuator file writer tests", Ordered, func() {
 	Context("Actuator file writer with valid path", func() {
 		var tmpFilePath string
 		objs := &tc.TCObjects{
-			QDisc: types.NewIngressQdisc(),
+			QDisc: ingressQdisc,
 			Filters: []types.Filter{
 				types.NewFlowerFilterBuilder().WithProtocol(types.FilterProtocolIP).WithPriority(100).Build(),
 			},

--- a/pkg/tc/actuator_tc.go
+++ b/pkg/tc/actuator_tc.go
@@ -42,14 +42,14 @@ func (a *ActuatorTCImpl) Actuate(objects *TCObjects) error {
 	if objects.QDisc == nil {
 		// delete ingress qdisc if exist
 		if ingressQDiscExist {
-			return a.tcApi.QDiscDel(types.NewIngressQdisc())
+			return a.tcApi.QDiscDel(types.NewIngressQDiscBuilder().Build())
 		}
 		return nil
 	}
 
 	if len(objects.Filters) == 0 {
 		// delete filters in chain 0 if exist
-		chains, err := a.tcApi.ChainList(types.NewIngressQdisc())
+		chains, err := a.tcApi.ChainList(types.NewIngressQDiscBuilder().Build())
 		if err != nil {
 			return err
 		}

--- a/pkg/tc/actuator_tc_test.go
+++ b/pkg/tc/actuator_tc_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Actuator TC tests", func() {
 	var actuator tc.Actuator
 	var tcMock *tcmocks.TC
 	var logger klog.Logger
+	ingressQdisc := tctypes.NewIngressQDiscBuilder().Build()
 
 	BeforeEach(func() {
 		// init logger
@@ -62,7 +63,7 @@ var _ = Describe("Actuator TC tests", func() {
 	Context("Actuate Qdisc Only", func() {
 		It("fails if listing qdisc fails", func() {
 			tcObj := &tc.TCObjects{
-				QDisc: tctypes.NewIngressQdisc(),
+				QDisc: ingressQdisc,
 			}
 
 			tcMock.On("QDiscList").Return(nil, errors.New("test error!"))
@@ -74,7 +75,7 @@ var _ = Describe("Actuator TC tests", func() {
 		It("fails if delete qdisc fails", func() {
 			tcObj := &tc.TCObjects{}
 
-			tcMock.On("QDiscList").Return([]tctypes.QDisc{tctypes.NewIngressQdisc()}, nil)
+			tcMock.On("QDiscList").Return([]tctypes.QDisc{ingressQdisc}, nil)
 			tcMock.On("QDiscDel", mock.Anything).Return(errors.New("test error!"))
 
 			err := actuator.Actuate(tcObj)
@@ -85,7 +86,7 @@ var _ = Describe("Actuator TC tests", func() {
 			It("deletes ingress Qdisc when exists", func() {
 				tcObj := &tc.TCObjects{}
 
-				tcMock.On("QDiscList").Return([]tctypes.QDisc{tctypes.NewIngressQdisc()}, nil)
+				tcMock.On("QDiscList").Return([]tctypes.QDisc{ingressQdisc}, nil)
 				tcMock.On("QDiscDel", mock.MatchedBy(ingressQdiscMatch())).Return(nil)
 
 				err := actuator.Actuate(tcObj)
@@ -105,7 +106,7 @@ var _ = Describe("Actuator TC tests", func() {
 		When("TCObjects contain ingress Qdisc", func() {
 			It("does nothing if ingress Qdisc exist without chain 0", func() {
 				tcObj := &tc.TCObjects{
-					QDisc: tctypes.NewIngressQdisc(),
+					QDisc: ingressQdisc,
 				}
 
 				tcMock.On("QDiscList").Return([]tctypes.QDisc{}, nil)
@@ -118,7 +119,7 @@ var _ = Describe("Actuator TC tests", func() {
 
 			It("deletes chain 0 on ingress qdisc when exists", func() {
 				tcObj := &tc.TCObjects{
-					QDisc: tctypes.NewIngressQdisc(),
+					QDisc: ingressQdisc,
 				}
 
 				tcMock.On("QDiscList").Return([]tctypes.QDisc{}, nil)
@@ -135,10 +136,10 @@ var _ = Describe("Actuator TC tests", func() {
 
 			It("does nothing if ingress Qdisc exists, chain 0 does not exist", func() {
 				tcObj := &tc.TCObjects{
-					QDisc: tctypes.NewIngressQdisc(),
+					QDisc: ingressQdisc,
 				}
 
-				tcMock.On("QDiscList").Return([]tctypes.QDisc{tctypes.NewIngressQdisc()}, nil)
+				tcMock.On("QDiscList").Return([]tctypes.QDisc{ingressQdisc}, nil)
 				tcMock.On("ChainList", mock.Anything).Return([]tctypes.Chain{}, nil)
 
 				err := actuator.Actuate(tcObj)
@@ -147,7 +148,7 @@ var _ = Describe("Actuator TC tests", func() {
 
 			It("fails if delete chain fails", func() {
 				tcObj := &tc.TCObjects{
-					QDisc: tctypes.NewIngressQdisc(),
+					QDisc: ingressQdisc,
 				}
 
 				tcMock.On("QDiscList").Return([]tctypes.QDisc{}, nil)
@@ -194,7 +195,7 @@ var _ = Describe("Actuator TC tests", func() {
 
 		BeforeEach(func() {
 			tcObj = &tc.TCObjects{
-				QDisc:   tctypes.NewIngressQdisc(),
+				QDisc:   ingressQdisc,
 				Filters: neededFilters,
 			}
 		})
@@ -210,7 +211,7 @@ var _ = Describe("Actuator TC tests", func() {
 
 		When("filters provided in TCObjects, no filters set on ingress qdisc", func() {
 			BeforeEach(func() {
-				tcMock.On("QDiscList").Return([]tctypes.QDisc{tctypes.NewIngressQdisc()}, nil)
+				tcMock.On("QDiscList").Return([]tctypes.QDisc{ingressQdisc}, nil)
 			})
 
 			It("adds them to qdisc", func() {
@@ -246,7 +247,7 @@ var _ = Describe("Actuator TC tests", func() {
 
 		When("filters provided in TCObjects, and filters set on ingress qdisc", func() {
 			BeforeEach(func() {
-				tcMock.On("QDiscList").Return([]tctypes.QDisc{tctypes.NewIngressQdisc()}, nil)
+				tcMock.On("QDiscList").Return([]tctypes.QDisc{ingressQdisc}, nil)
 				tcMock.On("FilterList", mock.MatchedBy(ingressQdiscMatch())).Return(existingFilters, nil)
 			})
 

--- a/pkg/tc/driver/cmdline/tc_cmdline.go
+++ b/pkg/tc/driver/cmdline/tc_cmdline.go
@@ -88,7 +88,6 @@ func (t *TcCmdLineImpl) QDiscList() ([]types.QDisc, error) {
 			// skip non-ingress qdiscs
 			continue
 		}
-		qdisc := types.NewIngressQdisc()
 		handle, err := parseMajorMinor(q.Handle)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to parse qdisc Handle")
@@ -97,8 +96,7 @@ func (t *TcCmdLineImpl) QDiscList() ([]types.QDisc, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to parse qdisc Parent")
 		}
-		qdisc.Handle = &handle
-		qdisc.Parent = &parent
+		qdisc := types.NewIngressQDiscBuilder().WithParent(parent).WithHandle(handle).Build()
 		objs = append(objs, qdisc)
 	}
 	return objs, nil

--- a/pkg/tc/generator.go
+++ b/pkg/tc/generator.go
@@ -57,7 +57,7 @@ func (s *SimpleTCGenerator) GenerateFromPolicyRuleSet(ruleSet policyrules.Policy
 	}
 
 	// create qdisc obj
-	tcObj.QDisc = tctypes.NewIngressQdisc()
+	tcObj.QDisc = tctypes.NewIngressQDiscBuilder().Build()
 
 	if ruleSet.Rules == nil {
 		// no rules

--- a/pkg/tc/types/qdisc.go
+++ b/pkg/tc/types/qdisc.go
@@ -7,16 +7,24 @@ const (
 // QDiscType is the type of qdisc
 type QDiscType string
 
-// QDiscAttr holds QDisc object attributes
-type QDiscAttr struct {
-	Handle *uint32
+// QDiscAttrs holds QDisc object attributes
+type QDiscAttrs struct {
 	Parent *uint32
+	Handle *uint32
+}
+
+// NewQDiscAttrs creates new QDiscAttrs instance
+func NewQDiscAttrs(parent, handle *uint32) *QDiscAttrs {
+	return &QDiscAttrs{
+		Parent: parent,
+		Handle: handle,
+	}
 }
 
 // QDisc is an interface which represents a TC qdisc object
 type QDisc interface {
-	// Attrs returns QDiscAttr for a qdisc
-	Attrs() *QDiscAttr
+	// Attrs returns QDiscAttrs for a qdisc
+	Attrs() *QDiscAttrs
 	// Type returns the QDisc type
 	Type() QDiscType
 
@@ -26,13 +34,13 @@ type QDisc interface {
 
 // GenericQDisc is a generic qdisc of an arbitrary type
 type GenericQDisc struct {
-	QDiscAttr
+	QDiscAttrs
 	QdiscType QDiscType
 }
 
 // Attrs implements QDisc interface
-func (g *GenericQDisc) Attrs() *QDiscAttr {
-	return &g.QDiscAttr
+func (g *GenericQDisc) Attrs() *QDiscAttrs {
+	return &g.QDiscAttrs
 }
 
 // Type implements QDisc interface
@@ -46,13 +54,74 @@ func (g *GenericQDisc) GenCmdLineArgs() []string {
 	return []string{string(g.QdiscType)}
 }
 
-// NewIngressQdisc creates a new Ingress QDisc object
-func NewIngressQdisc() *GenericQDisc {
+// NewGenericQdisc creates a new Generic QDisc object
+func NewGenericQdisc(qDiscAttrs *QDiscAttrs, qType QDiscType) *GenericQDisc {
 	return &GenericQDisc{
-		QDiscAttr: QDiscAttr{
-			Handle: nil,
-			Parent: nil,
-		},
-		QdiscType: QDiscIngressType,
+		QDiscAttrs: *qDiscAttrs,
+		QdiscType:  qType,
 	}
+}
+
+// Builders
+
+// NewQDiscAttrsBuilder returns a new QDiscAttrsBuilder
+func NewQDiscAttrsBuilder() *QDiscAttrsBuilder {
+	return &QDiscAttrsBuilder{}
+}
+
+// QDiscAttrsBuilder is a QDiscAttrs builder
+type QDiscAttrsBuilder struct {
+	qDiscAttrs QDiscAttrs
+}
+
+// WithParent adds Parent to QDiscAttrsBuilder
+func (qb *QDiscAttrsBuilder) WithParent(p uint32) *QDiscAttrsBuilder {
+	qb.qDiscAttrs.Parent = &p
+	return qb
+}
+
+// WithHandle adds Handle to QDiscAttrsBuilder
+func (qb *QDiscAttrsBuilder) WithHandle(h uint32) *QDiscAttrsBuilder {
+	qb.qDiscAttrs.Handle = &h
+	return qb
+}
+
+// Build builds and returns a new QDiscAttrs instance
+// Note: calling Build() multiple times will not return a completely
+// new object on each call. that is, pointer/slice/map types will not be deep copied.
+// to create several objects, different builders should be used.
+func (qb *QDiscAttrsBuilder) Build() *QDiscAttrs {
+	return NewQDiscAttrs(qb.qDiscAttrs.Parent, qb.qDiscAttrs.Handle)
+}
+
+// NewIngressQDiscBuilder returns a new NewIngressQDiscBuilder
+func NewIngressQDiscBuilder() *IngressQDiscBuilder {
+	return &IngressQDiscBuilder{qDiscAttrsBuilder: NewQDiscAttrsBuilder(), qDiscType: QDiscIngressType}
+}
+
+// IngressQDiscBuilder is an IngressQDisc builder
+type IngressQDiscBuilder struct {
+	qDiscAttrsBuilder *QDiscAttrsBuilder
+	qDiscType         QDiscType
+}
+
+// WithParent adds Parent to IngressQDiscBuilder
+func (iqb *IngressQDiscBuilder) WithParent(p uint32) *IngressQDiscBuilder {
+	iqb.qDiscAttrsBuilder.WithParent(p)
+	return iqb
+}
+
+// WithHandle adds Handle to IngressQDiscBuilder
+func (iqb *IngressQDiscBuilder) WithHandle(h uint32) *IngressQDiscBuilder {
+	iqb.qDiscAttrsBuilder.WithHandle(h)
+	return iqb
+}
+
+// Build builds and returns a new GenericQDisc instance of type QDiscIngressType
+// Note: calling Build() multiple times will not return a completely
+// new object on each call. that is, pointer/slice/map types will not be deep copied.
+// to create several objects, different builders should be used.
+func (iqb *IngressQDiscBuilder) Build() *GenericQDisc {
+	attrs := iqb.qDiscAttrsBuilder.Build()
+	return NewGenericQdisc(attrs, iqb.qDiscType)
 }


### PR DESCRIPTION
Add builder to ingress qdisc to facilitate a way
to easily build ingress qdisc with parent and handle
QDiscAttrs.

In addition rename QDiscAttr to QdiscAttrs as a plural form
better reflects the type.

This change is needed for subsequent commits that add tests
to tc cmdline driver

unit tests are adjusted to the new API

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>